### PR TITLE
More tweaks and localisation

### DIFF
--- a/NiceWeather.xcodeproj/project.pbxproj
+++ b/NiceWeather.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		459FBAA9252DB65200173158 /* NiceWeatherSlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459FBAA8252DB65200173158 /* NiceWeatherSlowTests.swift */; };
 		459FBAD1252DC16800173158 /* XCTestCase+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 459FBAD0252DC16800173158 /* XCTestCase+Ext.swift */; };
 		459FBADF252DC1B700173158 /* weathertest.json in Resources */ = {isa = PBXBuildFile; fileRef = 459FBADE252DC1B700173158 /* weathertest.json */; };
+		45DAF5CC252F3C6C0096E12E /* utilitiesFunctions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45DAF5CB252F3C6C0096E12E /* utilitiesFunctions.swift */; };
 		45E59B9325274819006FD2C5 /* NiceWeatherApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E59B9225274819006FD2C5 /* NiceWeatherApp.swift */; };
 		45E59B9525274819006FD2C5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E59B9425274819006FD2C5 /* ContentView.swift */; };
 		45E59B972527481A006FD2C5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 45E59B962527481A006FD2C5 /* Assets.xcassets */; };
@@ -83,6 +84,7 @@
 		459FBAAA252DB65200173158 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		459FBAD0252DC16800173158 /* XCTestCase+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Ext.swift"; sourceTree = "<group>"; };
 		459FBADE252DC1B700173158 /* weathertest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = weathertest.json; sourceTree = "<group>"; };
+		45DAF5CB252F3C6C0096E12E /* utilitiesFunctions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = utilitiesFunctions.swift; sourceTree = "<group>"; };
 		45E59B8F25274819006FD2C5 /* NiceWeather.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NiceWeather.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		45E59B9225274819006FD2C5 /* NiceWeatherApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NiceWeatherApp.swift; sourceTree = "<group>"; };
 		45E59B9425274819006FD2C5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 				4582F1EB252CA5C500A3F464 /* NWError.swift */,
 				4582F1F0252CA60C00A3F464 /* Constants.swift */,
 				4515A411252CF4FA00A8E51E /* Device.swift */,
+				45DAF5CB252F3C6C0096E12E /* utilitiesFunctions.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -469,6 +472,7 @@
 				455E6FA5252B2C47000F0058 /* ShareButton.swift in Sources */,
 				4582F1EC252CA5C500A3F464 /* NWError.swift in Sources */,
 				4515A41D252CF93900A8E51E /* DateTime.swift in Sources */,
+				45DAF5CC252F3C6C0096E12E /* utilitiesFunctions.swift in Sources */,
 				4515A412252CF4FA00A8E51E /* Device.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/NiceWeather/ContentView.swift
+++ b/NiceWeather/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     @State private var timer: Timer?
     @State private var isSharedPresented: Bool = false
     @State private var citySelection: Location = WeatherModel.loadLastLocation()
-
+    
     var datetime: String {
         model.currentWeather?.datetime ?? ""
     }
@@ -47,8 +47,9 @@ struct ContentView: View {
         model.currentWeather?.maxTemperature ?? ""
     }
     
-    var humidity: Int {
-        model.currentWeather?.main.humidity ?? 0
+    var humidity: String {
+        let humidity = model.currentWeather?.main.humidity ?? 0
+        return getHumidityPercentageFormattedString(humidity: humidity)
     }
     
     var body: some View {
@@ -103,7 +104,7 @@ struct ContentView: View {
             }
             .preferredColorScheme(model.isDayTime ? .light : .dark )
         }
-
+        
     }
     
 }

--- a/NiceWeather/ContentView.swift
+++ b/NiceWeather/ContentView.swift
@@ -46,6 +46,10 @@ struct ContentView: View {
         model.currentWeather?.maxTemperature ?? ""
     }
     
+    var humidity: Int {
+        model.currentWeather?.main.humidity ?? 0
+    }
+    
     var body: some View {
         GeometryReader { geo in
             ZStack{
@@ -71,7 +75,7 @@ struct ContentView: View {
                     
                     TempMaxMin(tempMin: tempMin , tempMax: tempMax)
                     
-                    HumidityView(model: model)
+                    HumidityView(humidity: humidity)
                     
                     WindRose(windSpeed: windSpeed, direction: direction)
                     

--- a/NiceWeather/ContentView.swift
+++ b/NiceWeather/ContentView.swift
@@ -26,8 +26,9 @@ struct ContentView: View {
         model.currentWeather?.name ?? "Nowhere"
     }
     
-    var windSpeed: Double {
-        model.currentWeather?.wind.speed ?? 0.0
+    var windSpeed: (Double, String) {
+        let speed: Double = model.currentWeather?.wind.speed ?? 0.0
+        return (double: speed, stringFormatted: getSpeedformattedString(speed: speed))
     }
     
     var direction: Double {

--- a/NiceWeather/ContentView.swift
+++ b/NiceWeather/ContentView.swift
@@ -34,16 +34,16 @@ struct ContentView: View {
         model.currentWeather?.degrees ?? 0.0
     }
     
-    var temperature: Double {
-        model.currentWeather?.main.temp ?? 0.0
+    var temperature: String {
+        model.currentWeather?.temperature ?? ""
     }
     
-    var tempMin: Double {
-        model.currentWeather?.main.tempMin ?? 0.0
+    var tempMin: String {
+        model.currentWeather?.minTemperature ?? ""
     }
     
-    var tempMax: Double {
-        model.currentWeather?.main.tempMax ?? 0.0
+    var tempMax: String {
+        model.currentWeather?.maxTemperature ?? ""
     }
     
     var body: some View {

--- a/NiceWeather/ContentView.swift
+++ b/NiceWeather/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
     }
     
     var windSpeed: Double {
-        model.currentWeather?.wind?.speed ?? 0.0
+        model.currentWeather?.wind.speed ?? 0.0
     }
     
     var direction: Double {

--- a/NiceWeather/Model/CurrentWeather.swift
+++ b/NiceWeather/Model/CurrentWeather.swift
@@ -65,7 +65,7 @@ extension CurrentWeather {
         let date = dt
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone(secondsFromGMT: timezone)
-        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM dd, h:mm a")
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM d, h:mm a")
         return formatter.string(from: date)
     }
     

--- a/NiceWeather/Model/CurrentWeather.swift
+++ b/NiceWeather/Model/CurrentWeather.swift
@@ -39,7 +39,7 @@ struct CurrentWeather: Codable {
     
     struct MainWeatherData: Codable {
         let temp: Double
-        let feelsLike: Double?
+        let feelsLike: Double
         let tempMin: Double
         let tempMax: Double
         let pressure: Int?
@@ -58,16 +58,36 @@ struct CurrentWeather: Codable {
     }
 }
 
+// MARK: - Extension
+
 extension CurrentWeather {
     var datetime: String {
         let date = dt
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone(secondsFromGMT: timezone)
-        formatter.dateFormat = "EEEE, MMMM dd, h:mm a"
+        formatter.setLocalizedDateFormatFromTemplate("EEEE, MMMM dd, h:mm a")
         return formatter.string(from: date)
     }
+    
     var degrees: Double {
         guard case wind?.deg = wind?.deg else { return 0.0 }
         return (-45 - 180) + ((wind?.deg)!)
     }
+    
+    var temperature: String {
+        return getTempformattedString(temp: main.temp)
+    }
+    
+    var feelsLikeTemperature: String {
+        return getTempformattedString(temp: main.feelsLike)
+    }
+    
+    var minTemperature: String {
+        return getTempformattedString(temp: main.tempMin)
+    }
+    
+    var maxTemperature: String {
+        return getTempformattedString(temp: main.tempMax)
+    }
+  
 }

--- a/NiceWeather/Model/CurrentWeather.swift
+++ b/NiceWeather/Model/CurrentWeather.swift
@@ -14,7 +14,7 @@ struct CurrentWeather: Codable {
     //var base: Base?
     var main: MainWeatherData
     //var visibility: Double?
-    var wind: Wind?
+    var wind: Wind
     //var clouds: Cloud?
     var dt: Date
     //var sys: Sys?
@@ -70,8 +70,8 @@ extension CurrentWeather {
     }
     
     var degrees: Double {
-        guard case wind?.deg = wind?.deg else { return 0.0 }
-        return (-45 - 180) + ((wind?.deg)!)
+        guard case wind.deg = wind.deg else { return 0.0 }
+        return (-45 - 180) + ((wind.deg)!)
     }
     
     var temperature: String {
@@ -90,4 +90,7 @@ extension CurrentWeather {
         return getTempformattedString(temp: main.tempMax)
     }
   
+    var speed: String {
+        return getSpeedformattedString(speed: wind.speed)
+    }
 }

--- a/NiceWeather/Model/CurrentWeather.swift
+++ b/NiceWeather/Model/CurrentWeather.swift
@@ -43,7 +43,7 @@ struct CurrentWeather: Codable {
         let tempMin: Double
         let tempMax: Double
         let pressure: Int?
-        let humidity: Int
+        let humidity: Double
     }
     
     struct Wind: Codable {

--- a/NiceWeather/Utilities/Device.swift
+++ b/NiceWeather/Utilities/Device.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 struct Device {
-    
+    // UIDevice.current.userInterfaceIdiom == .pad
+    // or UIDevice.current.userInterfaceIdiom == .phone would not work in this case because Catalyst uses the ipad idiom apparently
     static var isiPhone: Bool {
         struct Singleton {
             static let deviceName = UIDevice.current.name

--- a/NiceWeather/Utilities/utilitiesFunctions.swift
+++ b/NiceWeather/Utilities/utilitiesFunctions.swift
@@ -1,0 +1,15 @@
+//
+//  utilitiesFunctions.swift
+//  NiceWeather
+//
+//  Created by Laurent B on 08/10/2020.
+//
+
+import Foundation
+
+func getTempformattedString(temp: Double) -> String {
+    let formatter = MeasurementFormatter()
+    let temperature = Measurement<UnitTemperature>(value: temp, unit: .celsius)
+    formatter.numberFormatter.maximumFractionDigits = 0
+    return formatter.string(from: temperature)
+}

--- a/NiceWeather/Utilities/utilitiesFunctions.swift
+++ b/NiceWeather/Utilities/utilitiesFunctions.swift
@@ -20,3 +20,10 @@ func getSpeedformattedString(speed: Double) -> String {
     formatter.numberFormatter.maximumFractionDigits = 1
     return formatter.string(from: speed)
 }
+
+func getHumidityPercentageFormattedString(humidity: Double) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .percent
+    let NShumidity = NSNumber(value:(humidity) / 100)
+    return formatter.string(from: NShumidity)!
+}

--- a/NiceWeather/Utilities/utilitiesFunctions.swift
+++ b/NiceWeather/Utilities/utilitiesFunctions.swift
@@ -13,3 +13,10 @@ func getTempformattedString(temp: Double) -> String {
     formatter.numberFormatter.maximumFractionDigits = 0
     return formatter.string(from: temperature)
 }
+
+func getSpeedformattedString(speed: Double) -> String {
+    let formatter = MeasurementFormatter()
+    let speed = Measurement<UnitSpeed>(value: speed, unit: .metersPerSecond)
+    formatter.numberFormatter.maximumFractionDigits = 1
+    return formatter.string(from: speed)
+}

--- a/NiceWeather/ViewModel/WeatherModel.swift
+++ b/NiceWeather/ViewModel/WeatherModel.swift
@@ -24,7 +24,7 @@ extension WeatherModel {
 
 class WeatherModel: ObservableObject {
     
-    @Published private(set) var currentWeather: CurrentWeather?
+    @Published  var currentWeather: CurrentWeather?
     
     @Published private(set) var currentLocation: Location = loadLastLocation() {
         didSet {

--- a/NiceWeather/Views/HumidityView.swift
+++ b/NiceWeather/Views/HumidityView.swift
@@ -8,11 +8,7 @@
 import SwiftUI
 
 struct HumidityView: View {
-    var model: WeatherModel
-    
-    var humidity: Int {
-        model.currentWeather?.main.humidity ?? 0
-    }
+    var humidity: Int
     
     var body: some View {
         Text("Humidity: \(humidity) %")

--- a/NiceWeather/Views/HumidityView.swift
+++ b/NiceWeather/Views/HumidityView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct HumidityView: View {
-    var humidity: Int
+    var humidity: String
     
     var body: some View {
-        Text("Humidity: \(humidity) %")
+        Text("Humidity: \(humidity)")
             .font(.title2)
             .bold()
             .opacity(0.8)

--- a/NiceWeather/Views/TempMaxMin.swift
+++ b/NiceWeather/Views/TempMaxMin.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct TempMaxMin: View {
-    var tempMin: Double
-    var tempMax: Double
+    var tempMin: String
+    var tempMax: String
     
     var body: some View {
         HStack {
-            Text("\(tempMax, specifier: "%.f")°").font(.title2).bold()
-            Text("\(tempMin, specifier: "%.f")°").font(.title2).opacity(0.8)
+            Text(tempMax).font(.title2).bold()
+            Text(tempMin).font(.title2).opacity(0.8)
         }
     }
 }

--- a/NiceWeather/Views/TemperatureView.swift
+++ b/NiceWeather/Views/TemperatureView.swift
@@ -8,13 +8,13 @@
 import SwiftUI
 
 struct TemperatureView: View {
-    var temperature: Double
+    var temperature: String
     
     var body: some View {
         HStack {
             SFSymbols.thermometer
                 .font(.largeTitle)
-            Text("\(temperature, specifier: "%.f")°").font(.largeTitle)
+            Text(temperature).font(.largeTitle)
         }
     }
 }

--- a/NiceWeather/Views/WeatherDescriptionView.swift
+++ b/NiceWeather/Views/WeatherDescriptionView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct WeatherDescriptionView: View {
     var image: UIImage?
     var weatherDescription: String
+    
     var body: some View {
         VStack{
             ZStack{

--- a/NiceWeather/Views/WindRose.swift
+++ b/NiceWeather/Views/WindRose.swift
@@ -10,15 +10,15 @@ import SwiftUI
 struct WindRose: View {
     @State private var isAnimating = false
     
-    var windSpeed: Double
+    var windSpeed: (Double, String)
     var direction: Double
-    
+
     var windRoseAnimation: Animation {
         if isAnimating {
-            return Animation.linear(duration: 8/windSpeed)
+            return Animation.linear(duration: 8/windSpeed.0)
                 .repeatForever(autoreverses: false)
         } else {
-            return Animation.linear(duration: 8/windSpeed)
+            return Animation.linear(duration: 8/windSpeed.0)
         }
     }
     
@@ -26,8 +26,7 @@ struct WindRose: View {
         VStack {
             HStack{
                 SFSymbols.wind
-                Text("Wind speed: \(windSpeed, specifier: "%.1f") m/s ")
-                    .bold()
+                Text(windSpeed.1)
                 SFSymbols.windDirection
                     .rotationEffect(Angle(degrees: direction))
                     .accessibility(label: Text("wind direction"))
@@ -35,7 +34,7 @@ struct WindRose: View {
             .font(Font.title2.monospacedDigit())
             .padding(5)
             
-            if Int(windSpeed) != 0 {
+            if Int(windSpeed.0) != 0 {
                 SFSymbols.windRose
                     .font(.system(size: 33, weight: .heavy))
                     .accessibility(label: Text("wind speed animation"))
@@ -51,8 +50,8 @@ struct WindRose: View {
 }
 
 
-struct WindRose_Previews: PreviewProvider {
-    static var previews: some View {
-        WindRose(windSpeed: 4.2, direction: 45.0)
-    }
-}
+//struct WindRose_Previews: PreviewProvider {
+//    static var previews: some View {
+//        WindRose(windSpeed: 4.2, direction: 45.0)
+//    }
+//}


### PR DESCRIPTION
According to Apple as shown in the WWDC talk about formatters: https://developer.apple.com/videos/play/wwdc2020/10160/
all values can be converted to a localised string which takes into account the region and language. Therefore I added this tweak, where the user can change F or Celsius from the iPhone setting region and not from the app. This has enormous advantages for support of over 100 languages.